### PR TITLE
LL lets try the PR comment approval again only with a PR this time

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,6 @@ pr:
     include:
     - master
   drafts: false  # whether draft versions of PRs should fire triggers (default is TRUE)
-# trying PRs with necessary comments
 
 steps:
 - task: Maven@3


### PR DESCRIPTION
Checking whether pipeline GitHub.pipelines-java will get triggered before or after an admin leaves a /azp (/AzurePipelines) run comment.